### PR TITLE
feat: send notification only if canister is running

### DIFF
--- a/functions/src/utils/segment.utils.ts
+++ b/functions/src/utils/segment.utils.ts
@@ -6,7 +6,10 @@ import type {
 const CYCLES_MIN_THRESHOLD = 500_000_000_000n as const;
 
 export const lowCycles = ({
-  status: {status, id},
+  status: {
+    status: {cycles},
+    id,
+  },
   type,
   cron_jobs,
 }: {
@@ -18,7 +21,7 @@ export const lowCycles = ({
     const minThreshold =
       threshold > CYCLES_MIN_THRESHOLD ? threshold : CYCLES_MIN_THRESHOLD;
 
-    return status.cycles < minThreshold;
+    return cycles < minThreshold;
   };
 
   const defaultThreshold = cron_jobs.statuses.cycles_threshold[0] ?? 0n;
@@ -51,3 +54,6 @@ export const lowCycles = ({
     cron_jobs.statuses.mission_control_cycles_threshold[0] ?? defaultThreshold,
   );
 };
+
+export const running = ({status: {status}}: {status: SegmentStatus}): boolean =>
+  "running" in status;

--- a/functions/src/utils/status.utils.ts
+++ b/functions/src/utils/status.utils.ts
@@ -3,7 +3,7 @@ import type {
   ListStatuses,
   Result,
 } from "../../declarations/observatory/observatory.did.js";
-import {lowCycles} from "./segment.utils.js";
+import {lowCycles, running} from "./segment.utils.js";
 
 const filterSegmentStatus = ({
   segmentStatus,
@@ -21,7 +21,7 @@ const filterSegmentStatus = ({
 
   const {Ok: status} = segmentStatus;
 
-  return lowCycles({status, type, cron_jobs});
+  return running({status}) && lowCycles({status, type, cron_jobs});
 };
 
 export const filterStatuses = ({


### PR DESCRIPTION
Assuming that developer has manually stopped a segment they do not want to be notified if it gets low on cycles.

There is a warning in the UI that explain that the canister might ultimately disappear while being stopped after some time.